### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 
 SRC = cue2pops.c
 
-CC = gcc
 CFLAGS = -Wall -Wextra
 
 CFLAGS_DEBUG = $(CFLAGS) -O0 -g -DDEBUG
@@ -27,5 +26,5 @@ install: cue2pops
 	$(CP) $(TARGET) $(INSTALL_DIR)
 
 clean:
-	$(RM) $(TARGET)
+	$(RM) -f $(TARGET)
 


### PR DESCRIPTION
1. Add `-f` to `make clean` target: I wrote a script that uses cue2pops, it runs `make clean all` to build it.  But since `-f` does not appear in `rm`, `make clean` fails when it's already clean.

2. I was compiling on FreeBSD, which does not have `gcc` by default, it uses `clang` which is reachable by typing `cc`.  I removed the `CC` definition.  Most `make` implementations will fill in `cc` for this if left unspecified.  I've built this on FreeBSD, Linux and Mac without issues.